### PR TITLE
fixed issue of filtering/searching for "Not supplied" values in fields; added new integration tests for atlas_counts()

### DIFF
--- a/galah/src/galah/galah_filter.py
+++ b/galah/src/galah/galah_filter.py
@@ -65,6 +65,9 @@ def galah_filter(f, ifgroupBy=False):
             # check if the filter is a number or a string and if there is a group by
             if parts[1].isdigit() and ifgroupBy:
                 returnString+="&fq={}:[{}]".format(parts[0],parts[1])
+            # if filter is querying a field that has no value
+            elif parts[1] == '':
+                returnString+="&fq=-{}:(*)".format(parts[0])
             else:
                 returnString += "&fq={}:({})".format(parts[0], parts[1])
 

--- a/galah/tests/integration_tests_galah.py
+++ b/galah/tests/integration_tests_galah.py
@@ -54,6 +54,23 @@ def test_atlas_counts_taxa_filter():
     filter1 = "year=2020"
     assert galah.atlas_counts(taxa,filters=filter1)['totalRecords'][0] > 0
 
+def test_atlas_counts_taxa_filter_empty():
+    taxa = "Vulpes vulpes"
+    filter1 = "year="
+    assert galah.atlas_counts(taxa,filters=filter1)['totalRecords'][0] > 0
+
+# test atlas_counts() can call search_taxa() and using two filters with the same field, return results for a single taxa
+def test_astlas_counts_taxa_same_filter():
+    taxa = "Anigozanthos manglesii"
+    f = ["year >=2018", "year <= 2022"]
+    assert galah.atlas_counts(taxa, filters=f)['totalRecords'][0] > 0
+
+# test atlas_counts() can call search_taxa() and using two filters with the same field, return results for a single taxa
+def test_astlas_counts_taxa_same_filter1():
+    taxa = "Anigozanthos manglesii"
+    f = ["year >=2018", "year <= 2022", "year!=2020"]
+    assert galah.atlas_counts(taxa, filters=f)['totalRecords'][0] > 0
+
 # test data quality filter
 def test_atlas_counts_taxa_filter_data_quality():
     taxa = "Vulpes vulpes"


### PR DESCRIPTION
Had to provide a different URL format for this case: `"&fq=-{}:(*)".format(parts[0])` or `"&fq=-{}:(*)".format(field)`